### PR TITLE
feat(ci-cd): add debugging step for GitHub secrets in staging workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -735,6 +735,19 @@ jobs:
             echo "🔍 Will use database: STAGING_DB_NAME"
           fi
 
+      - name: Debug GitHub secrets availability (Staging)
+        if: github.ref == 'refs/heads/staging'
+        run: |
+          echo "🔍 Checking GitHub secrets availability (without exposing values):"
+          echo "STAGING_DB_HOST: ${{ secrets.STAGING_DB_HOST != '' && 'SET' || 'NOT_SET' }}"
+          echo "STAGING_DB_PORT: ${{ secrets.STAGING_DB_PORT != '' && 'SET' || 'NOT_SET' }}"
+          echo "STAGING_DB_USERNAME: ${{ secrets.STAGING_DB_USERNAME != '' && 'SET' || 'NOT_SET' }}"
+          echo "STAGING_DB_PASSWORD: ${{ secrets.STAGING_DB_PASSWORD != '' && 'SET' || 'NOT_SET' }}"
+          echo "STAGING_DB_NAME: ${{ secrets.STAGING_DB_NAME != '' && 'SET' || 'NOT_SET' }}"
+          echo "STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL != '' && 'SET' || 'NOT_SET' }}"
+          echo "STAGING_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY != '' && 'SET' || 'NOT_SET' }}"
+          echo "STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY != '' && 'SET' || 'NOT_SET' }}"
+
       - name: Debug environment variables (Staging)
         if: github.ref == 'refs/heads/staging'
         run: pnpm run debug:env --filter=api


### PR DESCRIPTION
This pull request adds a debugging step to the GitHub Actions workflow for the staging branch. The new step checks the availability of GitHub secrets without exposing their values, ensuring that all required secrets are set correctly.

### Debugging enhancements:

* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R738-R750): Added a new step to debug the availability of GitHub secrets for the staging environment. This step outputs whether each secret is set or not, helping to identify missing or misconfigured secrets.