### PR TITLE
feat(migration): enhance category and product schema migration with existence checks

### DIFF
--- a/apps/api/src/migrations/1753316790537-Migration.ts
+++ b/apps/api/src/migrations/1753316790537-Migration.ts
@@ -1,37 +1,132 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class Migration1753316790537 implements MigrationInterface {
   name = 'Migration1753316790537';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "Category" DROP CONSTRAINT "FK_41185546107ec4b4774da68df2f"`,
-    );
-    await queryRunner.query(`ALTER TABLE "Category" DROP COLUMN "parent_id"`);
-    await queryRunner.query(`ALTER TABLE "Category" DROP COLUMN "level"`);
-    await queryRunner.query(`ALTER TABLE "Category" DROP COLUMN "use_yn"`);
-    await queryRunner.query(`ALTER TABLE "Category" DROP COLUMN "name"`);
-    await queryRunner.query(`ALTER TABLE "Category" DROP COLUMN "slug"`);
-    await queryRunner.query(`ALTER TABLE "Category" ADD "category1" text`);
-    await queryRunner.query(`ALTER TABLE "Category" ADD "category2" text`);
-    await queryRunner.query(`ALTER TABLE "Category" ADD "category3" text`);
-    await queryRunner.query(
-      `ALTER TABLE "Product" ADD "brandName" character varying`,
-    );
+    // Check if constraint exists before dropping it
+    const constraintExists = await queryRunner.query(`
+      SELECT 1 FROM information_schema.table_constraints 
+      WHERE constraint_name = 'FK_41185546107ec4b4774da68df2f' 
+      AND table_name = 'Category'
+    `);
+
+    if (constraintExists.length > 0) {
+      await queryRunner.query(
+        `ALTER TABLE "Category" DROP CONSTRAINT "FK_41185546107ec4b4774da68df2f"`,
+      );
+    }
+
+    // Check if columns exist before dropping them
+    const columnsToCheck = ['parent_id', 'level', 'use_yn', 'name', 'slug'];
+    for (const column of columnsToCheck) {
+      const columnExists = await queryRunner.query(`
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'Category' AND column_name = '${column}'
+      `);
+
+      if (columnExists.length > 0) {
+        await queryRunner.query(
+          `ALTER TABLE "Category" DROP COLUMN "${column}"`,
+        );
+      }
+    }
+
+    // Check if columns exist before adding them
+    const newColumnsToCheck = ['category1', 'category2', 'category3'];
+    for (const column of newColumnsToCheck) {
+      const columnExists = await queryRunner.query(`
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'Category' AND column_name = '${column}'
+      `);
+
+      if (columnExists.length === 0) {
+        await queryRunner.query(`ALTER TABLE "Category" ADD "${column}" text`);
+      }
+    }
+
+    // Check if brandName column exists before adding it
+    const brandNameExists = await queryRunner.query(`
+      SELECT 1 FROM information_schema.columns 
+      WHERE table_name = 'Product' AND column_name = 'brandName'
+    `);
+
+    if (brandNameExists.length === 0) {
+      await queryRunner.query(
+        `ALTER TABLE "Product" ADD "brandName" character varying`,
+      );
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "Product" DROP COLUMN "brandName"`);
-    await queryRunner.query(`ALTER TABLE "Category" DROP COLUMN "category3"`);
-    await queryRunner.query(`ALTER TABLE "Category" DROP COLUMN "category2"`);
-    await queryRunner.query(`ALTER TABLE "Category" DROP COLUMN "category1"`);
-    await queryRunner.query(`ALTER TABLE "Category" ADD "slug" text`);
-    await queryRunner.query(`ALTER TABLE "Category" ADD "name" text`);
-    await queryRunner.query(`ALTER TABLE "Category" ADD "use_yn" boolean`);
-    await queryRunner.query(`ALTER TABLE "Category" ADD "level" bigint`);
-    await queryRunner.query(`ALTER TABLE "Category" ADD "parent_id" integer`);
-    await queryRunner.query(
-      `ALTER TABLE "Category" ADD CONSTRAINT "FK_41185546107ec4b4774da68df2f" FOREIGN KEY ("parent_id") REFERENCES "Category"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
-    );
+    // Check if brandName column exists before dropping it
+    const brandNameExists = await queryRunner.query(`
+      SELECT 1 FROM information_schema.columns 
+      WHERE table_name = 'Product' AND column_name = 'brandName'
+    `);
+
+    if (brandNameExists.length > 0) {
+      await queryRunner.query(`ALTER TABLE "Product" DROP COLUMN "brandName"`);
+    }
+
+    // Check if new category columns exist before dropping them
+    const newColumnsToCheck = ['category3', 'category2', 'category1'];
+    for (const column of newColumnsToCheck) {
+      const columnExists = await queryRunner.query(`
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'Category' AND column_name = '${column}'
+      `);
+
+      if (columnExists.length > 0) {
+        await queryRunner.query(
+          `ALTER TABLE "Category" DROP COLUMN "${column}"`,
+        );
+      }
+    }
+
+    // Check if old columns exist before adding them back
+    const oldColumnsToRestore = [
+      { name: 'slug', type: 'text' },
+      { name: 'name', type: 'text' },
+      { name: 'use_yn', type: 'boolean' },
+      { name: 'level', type: 'bigint' },
+      { name: 'parent_id', type: 'integer' },
+    ];
+
+    for (const column of oldColumnsToRestore) {
+      const columnExists = await queryRunner.query(`
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'Category' AND column_name = '${column.name}'
+      `);
+
+      if (columnExists.length === 0) {
+        await queryRunner.query(
+          `ALTER TABLE "Category" ADD "${column.name}" ${column.type}`,
+        );
+      }
+    }
+
+    // Check if constraint exists before adding it back
+    const constraintExists = await queryRunner.query(`
+      SELECT 1 FROM information_schema.table_constraints 
+      WHERE constraint_name = 'FK_41185546107ec4b4774da68df2f' 
+      AND table_name = 'Category'
+    `);
+
+    if (constraintExists.length === 0) {
+      // Also check if parent_id column exists (required for the constraint)
+      const parentIdExists = await queryRunner.query(`
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'Category' AND column_name = 'parent_id'
+      `);
+
+      if (parentIdExists.length > 0) {
+        await queryRunner.query(
+          `ALTER TABLE "Category" ADD CONSTRAINT "FK_41185546107ec4b4774da68df2f" FOREIGN KEY ("parent_id") REFERENCES "Category"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
This pull request enhances the migration script `1753316790537-Migration.ts` to make it more robust by adding checks for the existence of constraints and columns before performing operations. This ensures that the migration can be executed safely even if the database schema has been altered or is in an unexpected state.

### Improvements to migration robustness:

* Added checks to verify if the foreign key constraint `FK_41185546107ec4b4774da68df2f` exists before attempting to drop or add it. This prevents errors when the constraint is missing or already present.
* Introduced checks to ensure columns (`parent_id`, `level`, `use_yn`, `name`, `slug`, `category1`, `category2`, `category3`, and `brandName`) exist before attempting to drop or add them. This avoids issues when columns are absent or already exist.