### PR TITLE
feat(product): add product_sk to ProductSearchResponseDto and update …

### DIFF
--- a/apps/api/src/product/dto/product-search-response.dto.ts
+++ b/apps/api/src/product/dto/product-search-response.dto.ts
@@ -2,6 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class ProductSearchResponseDto {
   @ApiProperty({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    description: 'Product ID',
+  })
+  product_sk: string;
+
+  @ApiProperty({
     example: 'Organic Apple',
     description: 'Product name',
   })

--- a/apps/api/src/product/product.service.ts
+++ b/apps/api/src/product/product.service.ts
@@ -491,6 +491,7 @@ export class ProductService {
     product: Product,
   ): ProductSearchResponseDto {
     return {
+      product_sk: product.productSk,
       name: product.name,
       brand_name: product.brandName,
       image_url: product.imageUrl,

--- a/apps/api/test/product-search.e2e-spec.ts
+++ b/apps/api/test/product-search.e2e-spec.ts
@@ -24,6 +24,7 @@ describe('Product Search (e2e)', () => {
         if (query.toLowerCase().includes('apple')) {
           return Promise.resolve([
             {
+              product_sk: '550e8400-e29b-41d4-a716-446655440001',
               name: 'Organic Apple',
               brand_name: 'Cheil Jedang',
               image_url: 'https://example.com/apple.jpg',
@@ -34,6 +35,7 @@ describe('Product Search (e2e)', () => {
         if (query.toLowerCase().includes('cheil')) {
           return Promise.resolve([
             {
+              product_sk: '550e8400-e29b-41d4-a716-446655440002',
               name: 'Rice Cake',
               brand_name: 'Cheil Jedang',
               image_url: 'https://example.com/rice-cake.jpg',
@@ -75,6 +77,7 @@ describe('Product Search (e2e)', () => {
       expect(response.body).toHaveLength(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(response.body[0]).toMatchObject({
+        product_sk: '550e8400-e29b-41d4-a716-446655440001',
         name: 'Organic Apple',
         brand_name: 'Cheil Jedang',
         image_url: 'https://example.com/apple.jpg',
@@ -91,6 +94,7 @@ describe('Product Search (e2e)', () => {
       expect(response.body).toHaveLength(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(response.body[0]).toMatchObject({
+        product_sk: '550e8400-e29b-41d4-a716-446655440002',
         name: 'Rice Cake',
         brand_name: 'Cheil Jedang',
         image_url: 'https://example.com/rice-cake.jpg',


### PR DESCRIPTION
This pull request introduces a new `product_sk` property to the `ProductSearchResponseDto` class, updates the `ProductService` to include this property in its response, and modifies the e2e tests to validate this new field. These changes enhance the API by providing a unique identifier for each product in search responses.

### API Enhancements:

* **Added `product_sk` property to `ProductSearchResponseDto`:** This new property represents the unique identifier for a product and is annotated with `@ApiProperty` for Swagger documentation. (`apps/api/src/product/dto/product-search-response.dto.ts`, [apps/api/src/product/dto/product-search-response.dto.tsR4-R9](diffhunk://#diff-a1427673747935ae6145939ed7296f0ce1b63e5c04c044190ae65b14b36cf48eR4-R9))
* **Updated `ProductService` to include `product_sk` in search responses:** The service now maps the `productSk` field from the `Product` entity to the `product_sk` property in the response DTO. (`apps/api/src/product/product.service.ts`, [apps/api/src/product/product.service.tsR494](diffhunk://#diff-7595ad52ffff1c4b18e86e03ea10babbfc25b946e65cf933e3cb502b434403cfR494))

### Test Updates:

* **Modified e2e tests to validate `product_sk`:** Updated mock responses and assertions in the product search e2e tests to include the `product_sk` field, ensuring proper integration and validation of the new property. (`apps/api/test/product-search.e2e-spec.ts`, [[1]](diffhunk://#diff-dd5cfb6370974f045f624ce906c29391e1fc1de6cf7fb82254eeaaf72d615a72R27) [[2]](diffhunk://#diff-dd5cfb6370974f045f624ce906c29391e1fc1de6cf7fb82254eeaaf72d615a72R38) [[3]](diffhunk://#diff-dd5cfb6370974f045f624ce906c29391e1fc1de6cf7fb82254eeaaf72d615a72R80) [[4]](diffhunk://#diff-dd5cfb6370974f045f624ce906c29391e1fc1de6cf7fb82254eeaaf72d615a72R97)