### PR TITLE
refactor(migration): improve store migration script for country_regio…

### DIFF
--- a/apps/api/src/migrations/1753477797042-AddCountryRegionToStore.ts
+++ b/apps/api/src/migrations/1753477797042-AddCountryRegionToStore.ts
@@ -7,11 +7,11 @@ export class AddCountryRegionToStore1753477797042
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "Store" ADD "country_region" character varying`,
+      `ALTER TABLE "Store" ADD COLUMN IF NOT EXISTS "country_region" character varying`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "Store" DROP COLUMN "country_region"`);
+    await queryRunner.query(`ALTER TABLE "Store" DROP COLUMN IF EXISTS "country_region"`);
   }
 }


### PR DESCRIPTION
This pull request updates the database migration for adding the `country_region` column to the `Store` table. The changes make the migration more robust by ensuring that the column is only added or removed if it does not already exist.

Migration improvements:

* Updated the `up` method in `AddCountryRegionToStore1753477797042` to use `ADD COLUMN IF NOT EXISTS` when adding the `country_region` column to the `Store` table, preventing errors if the column already exists.
* Updated the `down` method to use `DROP COLUMN IF EXISTS` when removing the `country_region` column, avoiding errors if the column does not exist.