### PR TITLE
refactor(migration): enhance product linking migration for idempotency and safety

### DIFF
--- a/apps/api/src/migrations/1753477797042-AddCountryRegionToStore.ts
+++ b/apps/api/src/migrations/1753477797042-AddCountryRegionToStore.ts
@@ -12,6 +12,8 @@ export class AddCountryRegionToStore1753477797042
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "Store" DROP COLUMN IF EXISTS "country_region"`);
+    await queryRunner.query(
+      `ALTER TABLE "Store" DROP COLUMN IF EXISTS "country_region"`,
+    );
   }
 }

--- a/apps/api/src/migrations/1753512220079-AddProductLinkingToNormalizedProduct.ts
+++ b/apps/api/src/migrations/1753512220079-AddProductLinkingToNormalizedProduct.ts
@@ -6,42 +6,78 @@ export class AddProductLinkingToNormalizedProduct1753512220079
   name = 'AddProductLinkingToNormalizedProduct1753512220079';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // Add product linking columns to normalized_products table
-    await queryRunner.query(`
-            ALTER TABLE "normalized_products" 
-            ADD COLUMN "linked_product_sk" uuid,
-            ADD COLUMN "linking_confidence" decimal(5,4),
-            ADD COLUMN "linking_method" varchar(50),
-            ADD COLUMN "linked_at" timestamp with time zone
-        `);
+    // Check if columns already exist before adding them
+    const columns = await queryRunner.query(`
+      SELECT column_name 
+      FROM information_schema.columns 
+      WHERE table_name = 'normalized_products' 
+      AND column_name IN ('linked_product_sk', 'linking_confidence', 'linking_method', 'linked_at')
+    `);
+    
+    const existingColumns = columns.map((row: any) => row.column_name);
+    
+    // Add product linking columns to normalized_products table (only if they don't exist)
+    if (existingColumns.length === 0) {
+      await queryRunner.query(`
+        ALTER TABLE "normalized_products" 
+        ADD COLUMN IF NOT EXISTS "linked_product_sk" uuid,
+        ADD COLUMN IF NOT EXISTS "linking_confidence" decimal(5,4),
+        ADD COLUMN IF NOT EXISTS "linking_method" varchar(50),
+        ADD COLUMN IF NOT EXISTS "linked_at" timestamp with time zone
+      `);
+    } else {
+      // Add columns individually if some already exist
+      if (!existingColumns.includes('linked_product_sk')) {
+        await queryRunner.query(`ALTER TABLE "normalized_products" ADD COLUMN "linked_product_sk" uuid`);
+      }
+      if (!existingColumns.includes('linking_confidence')) {
+        await queryRunner.query(`ALTER TABLE "normalized_products" ADD COLUMN "linking_confidence" decimal(5,4)`);
+      }
+      if (!existingColumns.includes('linking_method')) {
+        await queryRunner.query(`ALTER TABLE "normalized_products" ADD COLUMN "linking_method" varchar(50)`);
+      }
+      if (!existingColumns.includes('linked_at')) {
+        await queryRunner.query(`ALTER TABLE "normalized_products" ADD COLUMN "linked_at" timestamp with time zone`);
+      }
+    }
 
-    // Add foreign key constraint
-    await queryRunner.query(`
-            ALTER TABLE "normalized_products" 
-            ADD CONSTRAINT "FK_normalized_products_linked_product" 
-            FOREIGN KEY ("linked_product_sk") REFERENCES "Product"("product_sk") ON DELETE SET NULL
-        `);
+    // Check if foreign key constraint exists
+    const constraintExists = await queryRunner.query(`
+      SELECT constraint_name 
+      FROM information_schema.table_constraints 
+      WHERE table_name = 'normalized_products' 
+      AND constraint_name = 'FK_normalized_products_linked_product'
+    `);
 
-    // Add comments to columns
+    // Add foreign key constraint only if it doesn't exist
+    if (constraintExists.length === 0) {
+      await queryRunner.query(`
+        ALTER TABLE "normalized_products" 
+        ADD CONSTRAINT "FK_normalized_products_linked_product" 
+        FOREIGN KEY ("linked_product_sk") REFERENCES "Product"("product_sk") ON DELETE SET NULL
+      `);
+    }
+
+    // Add comments to columns (safe to re-run)
     await queryRunner.query(`
-            COMMENT ON COLUMN "normalized_products"."linking_confidence" IS 'Confidence score for the product link (0-1)';
-            COMMENT ON COLUMN "normalized_products"."linking_method" IS 'Method used for linking (barcode_match, embedding_similarity, etc.)';
-            COMMENT ON COLUMN "normalized_products"."linked_at" IS 'When the product was linked';
-        `);
+      COMMENT ON COLUMN "normalized_products"."linking_confidence" IS 'Confidence score for the product link (0-1)';
+      COMMENT ON COLUMN "normalized_products"."linking_method" IS 'Method used for linking (barcode_match, embedding_similarity, etc.)';
+      COMMENT ON COLUMN "normalized_products"."linked_at" IS 'When the product was linked';
+    `);
 
     // Add index for efficient querying by linked product
     await queryRunner.query(`
-            CREATE INDEX "IDX_normalized_products_linked_product_sk" 
-            ON "normalized_products" ("linked_product_sk")
-        `);
+      CREATE INDEX IF NOT EXISTS "IDX_normalized_products_linked_product_sk" 
+      ON "normalized_products" ("linked_product_sk")
+    `);
 
     // Add index for querying unlinked high-confidence products
     // BUSINESS RULE: Only products with confidence_score >= 0.8 are eligible for linking
     await queryRunner.query(`
-            CREATE INDEX "IDX_normalized_products_confidence_unlinked" 
-            ON "normalized_products" ("confidence_score", "linked_product_sk") 
-            WHERE "linked_product_sk" IS NULL AND "confidence_score" >= 0.80
-        `);
+      CREATE INDEX IF NOT EXISTS "IDX_normalized_products_confidence_unlinked" 
+      ON "normalized_products" ("confidence_score", "linked_product_sk") 
+      WHERE "linked_product_sk" IS NULL AND "confidence_score" >= 0.80
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/apps/api/src/migrations/1753512220079-AddProductLinkingToNormalizedProduct.ts
+++ b/apps/api/src/migrations/1753512220079-AddProductLinkingToNormalizedProduct.ts
@@ -7,15 +7,15 @@ export class AddProductLinkingToNormalizedProduct1753512220079
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Check if columns already exist before adding them
-    const columns = await queryRunner.query(`
+    const columns = (await queryRunner.query(`
       SELECT column_name 
       FROM information_schema.columns 
       WHERE table_name = 'normalized_products' 
       AND column_name IN ('linked_product_sk', 'linking_confidence', 'linking_method', 'linked_at')
-    `);
-    
-    const existingColumns = columns.map((row: any) => row.column_name);
-    
+    `)) as { column_name: string }[];
+
+    const existingColumns = columns.map((row) => row.column_name);
+
     // Add product linking columns to normalized_products table (only if they don't exist)
     if (existingColumns.length === 0) {
       await queryRunner.query(`
@@ -28,26 +28,34 @@ export class AddProductLinkingToNormalizedProduct1753512220079
     } else {
       // Add columns individually if some already exist
       if (!existingColumns.includes('linked_product_sk')) {
-        await queryRunner.query(`ALTER TABLE "normalized_products" ADD COLUMN "linked_product_sk" uuid`);
+        await queryRunner.query(
+          `ALTER TABLE "normalized_products" ADD COLUMN "linked_product_sk" uuid`,
+        );
       }
       if (!existingColumns.includes('linking_confidence')) {
-        await queryRunner.query(`ALTER TABLE "normalized_products" ADD COLUMN "linking_confidence" decimal(5,4)`);
+        await queryRunner.query(
+          `ALTER TABLE "normalized_products" ADD COLUMN "linking_confidence" decimal(5,4)`,
+        );
       }
       if (!existingColumns.includes('linking_method')) {
-        await queryRunner.query(`ALTER TABLE "normalized_products" ADD COLUMN "linking_method" varchar(50)`);
+        await queryRunner.query(
+          `ALTER TABLE "normalized_products" ADD COLUMN "linking_method" varchar(50)`,
+        );
       }
       if (!existingColumns.includes('linked_at')) {
-        await queryRunner.query(`ALTER TABLE "normalized_products" ADD COLUMN "linked_at" timestamp with time zone`);
+        await queryRunner.query(
+          `ALTER TABLE "normalized_products" ADD COLUMN "linked_at" timestamp with time zone`,
+        );
       }
     }
 
     // Check if foreign key constraint exists
-    const constraintExists = await queryRunner.query(`
+    const constraintExists = (await queryRunner.query(`
       SELECT constraint_name 
       FROM information_schema.table_constraints 
       WHERE table_name = 'normalized_products' 
       AND constraint_name = 'FK_normalized_products_linked_product'
-    `);
+    `)) as { constraint_name: string }[];
 
     // Add foreign key constraint only if it doesn't exist
     if (constraintExists.length === 0) {

--- a/apps/api/src/migrations/1753995762764-AddFirstLastNameFields.ts
+++ b/apps/api/src/migrations/1753995762764-AddFirstLastNameFields.ts
@@ -4,58 +4,67 @@ export class AddFirstLastNameFields1753995762764 implements MigrationInterface {
   name = 'AddFirstLastNameFields1753995762764';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // Add first_name and last_name columns
+    // Add first_name and last_name columns if they don't exist
     await queryRunner.query(
-      `ALTER TABLE "User" ADD "first_name" character varying`,
+      `ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "first_name" character varying`,
     );
     await queryRunner.query(
-      `ALTER TABLE "User" ADD "last_name" character varying`,
+      `ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "last_name" character varying`,
     );
 
-    // Migrate existing displayName data to first_name and last_name
-    await queryRunner.query(`
-            UPDATE "User" 
-            SET 
-                "first_name" = CASE 
-                    WHEN "display_name" IS NOT NULL AND trim("display_name") != '' THEN
-                        trim(split_part(trim("display_name"), ' ', 1))
-                    ELSE NULL
-                END,
-                "last_name" = CASE 
-                    WHEN "display_name" IS NOT NULL AND trim("display_name") != '' AND array_length(string_to_array(trim("display_name"), ' '), 1) > 1 THEN
-                        trim(substr("display_name", length(split_part(trim("display_name"), ' ', 1)) + 2))
-                    ELSE NULL
-                END
-            WHERE "display_name" IS NOT NULL AND trim("display_name") != ''
-        `);
+    // Check if display_name column exists before trying to migrate data
+    const displayNameExists = await queryRunner.query(`
+      SELECT column_name 
+      FROM information_schema.columns 
+      WHERE table_name = 'User' AND column_name = 'display_name'
+    `);
 
-    // Remove the old display_name column
-    await queryRunner.query(`ALTER TABLE "User" DROP COLUMN "display_name"`);
+    if (displayNameExists.length > 0) {
+      // Migrate existing displayName data to first_name and last_name
+      await queryRunner.query(`
+        UPDATE "User" 
+        SET 
+            "first_name" = CASE 
+                WHEN "display_name" IS NOT NULL AND trim("display_name") != '' THEN
+                    trim(split_part(trim("display_name"), ' ', 1))
+                ELSE NULL
+            END,
+            "last_name" = CASE 
+                WHEN "display_name" IS NOT NULL AND trim("display_name") != '' AND array_length(string_to_array(trim("display_name"), ' '), 1) > 1 THEN
+                    trim(substr("display_name", length(split_part(trim("display_name"), ' ', 1)) + 2))
+                ELSE NULL
+            END
+        WHERE "display_name" IS NOT NULL AND trim("display_name") != ''
+      `);
+
+      // Remove the old display_name column
+      await queryRunner.query(`ALTER TABLE "User" DROP COLUMN IF EXISTS "display_name"`);
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    // Add back display_name column
+    // Add back display_name column if it doesn't exist
     await queryRunner.query(
-      `ALTER TABLE "User" ADD "display_name" character varying`,
+      `ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "display_name" character varying`,
     );
 
     // Migrate data back from first_name and last_name to display_name
     await queryRunner.query(`
-            UPDATE "User" 
-            SET "display_name" = CASE 
-                WHEN "first_name" IS NOT NULL AND "last_name" IS NOT NULL THEN
-                    CONCAT("first_name", ' ', "last_name")
-                WHEN "first_name" IS NOT NULL THEN
-                    "first_name"
-                WHEN "last_name" IS NOT NULL THEN
-                    "last_name"
-                ELSE NULL
-            END
-            WHERE "first_name" IS NOT NULL OR "last_name" IS NOT NULL
-        `);
+      UPDATE "User" 
+      SET "display_name" = CASE 
+          WHEN "first_name" IS NOT NULL AND "last_name" IS NOT NULL THEN
+              CONCAT("first_name", ' ', "last_name")
+          WHEN "first_name" IS NOT NULL THEN
+              "first_name"
+          WHEN "last_name" IS NOT NULL THEN
+              "last_name"
+          ELSE NULL
+      END
+      WHERE "first_name" IS NOT NULL OR "last_name" IS NOT NULL
+    `);
 
-    // Drop the new columns
-    await queryRunner.query(`ALTER TABLE "User" DROP COLUMN "last_name"`);
-    await queryRunner.query(`ALTER TABLE "User" DROP COLUMN "first_name"`);
+    // Drop the new columns if they exist
+    await queryRunner.query(`ALTER TABLE "User" DROP COLUMN IF EXISTS "last_name"`);
+    await queryRunner.query(`ALTER TABLE "User" DROP COLUMN IF EXISTS "first_name"`);
   }
 }

--- a/apps/api/src/migrations/1753995762764-AddFirstLastNameFields.ts
+++ b/apps/api/src/migrations/1753995762764-AddFirstLastNameFields.ts
@@ -13,11 +13,11 @@ export class AddFirstLastNameFields1753995762764 implements MigrationInterface {
     );
 
     // Check if display_name column exists before trying to migrate data
-    const displayNameExists = await queryRunner.query(`
+    const displayNameExists = (await queryRunner.query(`
       SELECT column_name 
       FROM information_schema.columns 
       WHERE table_name = 'User' AND column_name = 'display_name'
-    `);
+    `)) as { column_name: string }[];
 
     if (displayNameExists.length > 0) {
       // Migrate existing displayName data to first_name and last_name
@@ -38,7 +38,9 @@ export class AddFirstLastNameFields1753995762764 implements MigrationInterface {
       `);
 
       // Remove the old display_name column
-      await queryRunner.query(`ALTER TABLE "User" DROP COLUMN IF EXISTS "display_name"`);
+      await queryRunner.query(
+        `ALTER TABLE "User" DROP COLUMN IF EXISTS "display_name"`,
+      );
     }
   }
 
@@ -64,7 +66,11 @@ export class AddFirstLastNameFields1753995762764 implements MigrationInterface {
     `);
 
     // Drop the new columns if they exist
-    await queryRunner.query(`ALTER TABLE "User" DROP COLUMN IF EXISTS "last_name"`);
-    await queryRunner.query(`ALTER TABLE "User" DROP COLUMN IF EXISTS "first_name"`);
+    await queryRunner.query(
+      `ALTER TABLE "User" DROP COLUMN IF EXISTS "last_name"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" DROP COLUMN IF EXISTS "first_name"`,
+    );
   }
 }


### PR DESCRIPTION
This pull request improves the safety and idempotency of two database migration scripts by adding checks before modifying tables, columns, and indexes. This helps prevent errors when migrations are re-run or when the database schema is in an unexpected state.

**Migration improvements for `normalized_products` table:**

* Added checks to ensure product linking columns (`linked_product_sk`, `linking_confidence`, `linking_method`, `linked_at`) are only added if they do not already exist, and added logic to add missing columns individually if some already exist.
* Added a check to only add the foreign key constraint `FK_normalized_products_linked_product` if it does not already exist.
* Modified index creation to use `CREATE INDEX IF NOT EXISTS` for `IDX_normalized_products_linked_product_sk` and `IDX_normalized_products_confidence_unlinked` to avoid errors if the indexes already exist.

**Migration improvements for `User` table:**

* Changed addition of `first_name` and `last_name` columns to use `ADD COLUMN IF NOT EXISTS`, and added a check to only migrate `display_name` data if the column exists.
* Changed removal of `display_name` and new columns to use `DROP COLUMN IF EXISTS`, and ensured addition of `display_name` in the down migration uses `ADD COLUMN IF NOT EXISTS`. [[1]](diffhunk://#diff-185ce2b0398d6f2c0f3a07fed31f63fc640bd6a261d67542664ef105d3151a78L33-R48) [[2]](diffhunk://#diff-185ce2b0398d6f2c0f3a07fed31f63fc640bd6a261d67542664ef105d3151a78L57-R68)