### PR TITLE
refactor(migration): enhance receipt item normalization migration for idempotency and safety

### DIFF
--- a/apps/api/src/migrations/1753911308408-FixLinkedProductSkTypeToUuid.ts
+++ b/apps/api/src/migrations/1753911308408-FixLinkedProductSkTypeToUuid.ts
@@ -6,6 +6,30 @@ export class FixLinkedProductSkTypeToUuid1753911308408
   name = 'FixLinkedProductSkTypeToUuid1753911308408';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Check if the column exists and get its type
+    const columnExists = (await queryRunner.query(`
+      SELECT data_type 
+      FROM information_schema.columns 
+      WHERE table_schema = 'public' 
+      AND table_name = 'normalized_products'
+      AND column_name = 'linked_product_sk'
+    `)) as { data_type: string }[];
+
+    // If column doesn't exist or is already UUID, skip
+    if (columnExists.length === 0) {
+      console.log(
+        'linked_product_sk column does not exist. Skipping type change.',
+      );
+      return;
+    }
+
+    if (columnExists[0].data_type === 'uuid') {
+      console.log(
+        'linked_product_sk column is already UUID type. No changes needed.',
+      );
+      return;
+    }
+
     // Drop foreign key constraint first
     await queryRunner.query(
       `ALTER TABLE "normalized_products" DROP CONSTRAINT IF EXISTS "FK_8988cdcae12e54d0c88e196ad38"`,


### PR DESCRIPTION
This pull request enhances the robustness and idempotency of several database migrations by adding checks before altering tables, columns, indexes, and constraints. The changes ensure that migrations can be safely re-run and avoid errors when schema elements already exist or are of the correct type.

Key improvements and safeguards added:

**Helper Functions for Safe Operations**
* Introduced `createIndexIfNotExists` and `addConstraintIfNotExists` helper functions to safely create indexes and constraints only if they do not already exist, reducing the risk of migration failures. [[1]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R9-R46) [[2]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R260-R372)

**Column and Type Modifications**
* Added existence and type checks before adding or modifying columns (`final_price`, `embedding`, `linked_product_sk`) in `receipt_item_normalizations` and `normalized_products`, ensuring columns are only altered when necessary. [[1]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R123-R138) [[2]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R154-R179) [[3]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R198-R250)
* In the migration for fixing `linked_product_sk` type, added logic to skip type changes if the column does not exist or is already of type `uuid`.

**Enum Handling**
* Improved enum migration logic by checking for the existence of old and new enum types before renaming, creating, or dropping them, preventing conflicts and redundant operations. [[1]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R198-R250) [[2]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R260-R372)

**Index and Constraint Creation**
* Updated index and constraint creation steps to use the new helper functions, ensuring that these operations are only performed when necessary and avoiding duplicate creation attempts.