### PR TITLE
refactor(migration): enhance receipt item normalization migrations with dynamic table name resolution

### DIFF
--- a/apps/api/src/migrations/1753316790537-Migration.ts
+++ b/apps/api/src/migrations/1753316790537-Migration.ts
@@ -15,7 +15,7 @@ export class Migration1753316790537 implements MigrationInterface {
       );
     `)) as [{ exists: boolean }];
 
-        if (!tableExists[0].exists) {
+    if (!tableExists[0].exists) {
       // Still check and add brandName to Product table if it exists
       const productTableExists = (await queryRunner.query(`
         SELECT EXISTS (
@@ -38,7 +38,7 @@ export class Migration1753316790537 implements MigrationInterface {
           );
         }
       }
-      
+
       return;
     }
 


### PR DESCRIPTION
This pull request improves the reliability of database migrations involving the `ReceiptItem` table by introducing logic to dynamically detect the actual table name, regardless of case or naming convention differences across environments. This change ensures that migrations work correctly even if the table is named differently (e.g., `ReceiptItem`, `receiptitem`, or `receipt_item`). The update is applied consistently across both the normalization refactor and the final price addition migrations.

**Dynamic table name resolution for migrations:**

* Added a helper method `getReceiptItemTableName` to both `1753435000000-RefactorReceiptItemNormalization.ts` and `1753909203198-AddFinalPriceToReceiptItemNormalization.ts` to detect the correct `ReceiptItem` table name by checking common naming variants in the database. All queries and schema changes now use this dynamically resolved table name instead of hardcoding `"ReceiptItem"`. [[1]](diffhunk://#diff-34d926171fd53d9ed3db9f773ed741641b3bc2ede391ade2acc467fb977c5611R9-R13) [[2]](diffhunk://#diff-34d926171fd53d9ed3db9f773ed741641b3bc2ede391ade2acc467fb977c5611R373-R403) [[3]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R9-R13) [[4]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1L549-R588)

**Migration query updates for consistency:**

* Updated all references to the `ReceiptItem` table in migration queries (including foreign key constraints, column additions/drops, and data updates) to use the dynamically determined table name, ensuring compatibility across different environments. [[1]](diffhunk://#diff-34d926171fd53d9ed3db9f773ed741641b3bc2ede391ade2acc467fb977c5611L46-R51) [[2]](diffhunk://#diff-34d926171fd53d9ed3db9f773ed741641b3bc2ede391ade2acc467fb977c5611L76-R81) [[3]](diffhunk://#diff-34d926171fd53d9ed3db9f773ed741641b3bc2ede391ade2acc467fb977c5611R92-R129) [[4]](diffhunk://#diff-34d926171fd53d9ed3db9f773ed741641b3bc2ede391ade2acc467fb977c5611L146-R156) [[5]](diffhunk://#diff-34d926171fd53d9ed3db9f773ed741641b3bc2ede391ade2acc467fb977c5611R165-R246) [[6]](diffhunk://#diff-34d926171fd53d9ed3db9f773ed741641b3bc2ede391ade2acc467fb977c5611L249-R281) [[7]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1L355-R360) [[8]](diffhunk://#diff-df285ba4f65b798864cd434ffa45e8fa2374481bbdb59bff082f2739597b5af1R382-R384)

These changes make the migrations more robust and prevent failures due to table name mismatches in various deployment scenarios.