### PR TITLE
refactor(migration): enhance foreign key constraint handling for Product table

### DIFF
--- a/apps/api/src/migrations/1753911308408-FixLinkedProductSkTypeToUuid.ts
+++ b/apps/api/src/migrations/1753911308408-FixLinkedProductSkTypeToUuid.ts
@@ -59,10 +59,28 @@ export class FixLinkedProductSkTypeToUuid1753911308408
       `ALTER TABLE "normalized_products" ADD "linked_product_sk" uuid`,
     );
 
-    // Recreate foreign key constraint to Product.product_sk (UUID)
-    await queryRunner.query(
-      `ALTER TABLE "normalized_products" ADD CONSTRAINT "FK_8988cdcae12e54d0c88e196ad38" FOREIGN KEY ("linked_product_sk") REFERENCES "Product"("product_sk") ON DELETE NO ACTION ON UPDATE NO ACTION`,
-    );
+    // Recreate foreign key constraint to Product.product_sk (UUID) - only if Product table exists
+    const productTableExists = (await queryRunner.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables 
+        WHERE table_schema = 'public' 
+        AND table_name = 'Product'
+      );
+    `)) as [{ exists: boolean }];
+
+    if (productTableExists[0]?.exists) {
+      console.log('✅ Product table found, creating foreign key constraint...');
+      await queryRunner.query(
+        `ALTER TABLE "normalized_products" ADD CONSTRAINT "FK_8988cdcae12e54d0c88e196ad38" FOREIGN KEY ("linked_product_sk") REFERENCES "Product"("product_sk") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      );
+    } else {
+      console.log(
+        '⚠️  Product table not found, skipping foreign key constraint creation',
+      );
+      console.log(
+        'ℹ️   Foreign key constraint can be added later when Product table exists',
+      );
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
@@ -82,9 +100,9 @@ export class FixLinkedProductSkTypeToUuid1753911308408
       return;
     }
 
-    // Drop foreign key constraint first
+    // Drop foreign key constraint first (only if it exists)
     await queryRunner.query(
-      `ALTER TABLE "normalized_products" DROP CONSTRAINT "FK_8988cdcae12e54d0c88e196ad38"`,
+      `ALTER TABLE "normalized_products" DROP CONSTRAINT IF EXISTS "FK_8988cdcae12e54d0c88e196ad38"`,
     );
 
     // Drop and recreate the column with integer type
@@ -95,9 +113,19 @@ export class FixLinkedProductSkTypeToUuid1753911308408
       `ALTER TABLE "normalized_products" ADD "linked_product_sk" integer`,
     );
 
-    // Recreate foreign key constraint to Product.id (integer) - for rollback
-    await queryRunner.query(
-      `ALTER TABLE "normalized_products" ADD CONSTRAINT "FK_8988cdcae12e54d0c88e196ad38" FOREIGN KEY ("linked_product_sk") REFERENCES "Product"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
-    );
+    // Recreate foreign key constraint to Product.id (integer) - only if Product table exists
+    const productTableExists = (await queryRunner.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables 
+        WHERE table_schema = 'public' 
+        AND table_name = 'Product'
+      );
+    `)) as [{ exists: boolean }];
+
+    if (productTableExists[0]?.exists) {
+      await queryRunner.query(
+        `ALTER TABLE "normalized_products" ADD CONSTRAINT "FK_8988cdcae12e54d0c88e196ad38" FOREIGN KEY ("linked_product_sk") REFERENCES "Product"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      );
+    }
   }
 }


### PR DESCRIPTION
This pull request improves the robustness of two database migration scripts by ensuring that foreign key constraints involving the `Product` table are only created or dropped if the `Product` table actually exists. This prevents migration failures in environments where the `Product` table may not yet be present. Additionally, the migrations now provide clearer log messages for these scenarios.

**Migration safety and reliability improvements:**

* In both `1753512220079-AddProductLinkingToNormalizedProduct.ts` and `1753911308408-FixLinkedProductSkTypeToUuid.ts`, added checks before creating or dropping foreign key constraints to ensure the `Product` table exists, preventing errors if the table is missing. [[1]](diffhunk://#diff-1ccc3afb94f9c3a4efaa72de02388a5f762fe2a3b354f77bd15c3dee8b7cbd89R68-R79) [[2]](diffhunk://#diff-1ccc3afb94f9c3a4efaa72de02388a5f762fe2a3b354f77bd15c3dee8b7cbd89L132-R165) [[3]](diffhunk://#diff-90ac4403237839be9a29627a996475d9d2eb978b42ff527da34c06a43eac951dL62-R83) [[4]](diffhunk://#diff-90ac4403237839be9a29627a996475d9d2eb978b42ff527da34c06a43eac951dL98-R131)
* Updated the logic for dropping foreign key constraints to use `DROP CONSTRAINT IF EXISTS`, making the rollback process idempotent and safer.

**Developer experience improvements:**

* Added clear console log messages to inform whether the foreign key constraint is being created or skipped, and guidance for adding the constraint later if needed. [[1]](diffhunk://#diff-1ccc3afb94f9c3a4efaa72de02388a5f762fe2a3b354f77bd15c3dee8b7cbd89R96-R103) [[2]](diffhunk://#diff-90ac4403237839be9a29627a996475d9d2eb978b42ff527da34c06a43eac951dL62-R83)

These changes make the migrations more resilient and user-friendly, especially when running in different database states.