### PR TITLE
refactor(migration): enhance table checks in InitialSchema and DiagnosticTableCheck migrations

### DIFF
--- a/apps/api/src/migrations/1700000000000-InitialSchema.ts
+++ b/apps/api/src/migrations/1700000000000-InitialSchema.ts
@@ -36,11 +36,20 @@ export class InitialSchema1700000000000 implements MigrationInterface {
     }
 
     // PRODUCTION SAFETY: Check if this is being run on an existing database
+    // Exclude system tables that are safe to ignore
     const existingTables = (await queryRunner.query(`
       SELECT table_name FROM information_schema.tables 
       WHERE table_schema = 'public' 
       AND table_type = 'BASE TABLE'
-      AND table_name NOT IN ('typeorm_metadata', 'migrations')
+      AND table_name NOT IN (
+        'typeorm_metadata', 
+        'migrations',
+        'spatial_ref_sys',        -- PostGIS system table
+        'geography_columns',      -- PostGIS system table  
+        'geometry_columns',       -- PostGIS system table
+        'raster_columns',         -- PostGIS system table
+        'raster_overviews'        -- PostGIS system table
+      )
     `)) as { table_name: string }[];
 
     if (existingTables.length > 0) {

--- a/apps/api/src/migrations/1700000000001-DiagnosticTableCheck.ts
+++ b/apps/api/src/migrations/1700000000001-DiagnosticTableCheck.ts
@@ -75,11 +75,20 @@ export class DiagnosticTableCheck1700000000001 implements MigrationInterface {
       );
     }
 
-    // Also check for unexpected tables
+    // Also check for unexpected tables (excluding system tables)
+    const systemTables = [
+      'migrations',
+      'spatial_ref_sys',
+      'geography_columns',
+      'geometry_columns',
+      'raster_columns',
+      'raster_overviews',
+    ];
+
     const unexpectedTables = foundTableNames.filter(
       (name) =>
         !expectedTables.includes(name) &&
-        name !== 'migrations' &&
+        !systemTables.includes(name) &&
         !name.startsWith('typeorm_'),
     );
 


### PR DESCRIPTION
This pull request improves the reliability of database migration scripts by ensuring that system tables—especially those created by PostGIS—are properly excluded from checks that verify existing or unexpected tables. This helps prevent false positives and errors during migrations on databases that include spatial extensions.

**Migration script improvements:**

* Updated the exclusion list in the `InitialSchema1700000000000` migration to ignore common PostGIS system tables (`spatial_ref_sys`, `geography_columns`, `geometry_columns`, `raster_columns`, `raster_overviews`) when checking for existing tables.
* Refactored the diagnostic table check in `DiagnosticTableCheck1700000000001` to use a `systemTables` array, ensuring these same PostGIS system tables are excluded from the list of unexpected tables.