### PR TITLE
feat(barcode): add POST endpoint for product lookup and enhance response DTO

### DIFF
--- a/apps/api/src/barcode/barcode.service.spec.ts
+++ b/apps/api/src/barcode/barcode.service.spec.ts
@@ -59,6 +59,7 @@ describe('BarcodeService', () => {
 
       expect(result).toEqual({
         id: 'test-uuid',
+        product_sk: 'test-uuid',
         name: 'Test Product',
         barcode: '1234567890',
         brand: undefined,

--- a/apps/api/src/barcode/barcode.service.ts
+++ b/apps/api/src/barcode/barcode.service.ts
@@ -50,6 +50,7 @@ export class BarcodeService {
   ): ProductResponseDto {
     return {
       id: product.productSk,
+      product_sk: product.productSk,
       name: product.name,
       barcode: product.barcode || '',
       barcodeType: product.barcodeType,

--- a/apps/api/src/barcode/dto/product-response.dto.ts
+++ b/apps/api/src/barcode/dto/product-response.dto.ts
@@ -9,6 +9,12 @@ export class ProductResponseDto {
   id: string;
 
   @ApiProperty({
+    description: 'Product SKU (same as id, for mobile compatibility)',
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  })
+  product_sk: string;
+
+  @ApiProperty({
     description: 'Product name',
     example: 'Organic Bananas',
   })


### PR DESCRIPTION
This pull request adds a new POST endpoint for barcode lookup to improve mobile compatibility and updates the product response structure to include a `product_sk` field. The changes primarily affect the barcode controller, service, and response DTO.

### API Enhancements

* Added a new `POST /barcode/lookup` endpoint in `barcode.controller.ts` to allow barcode lookup via POST requests, which is more compatible with some mobile clients. This includes detailed Swagger documentation and custom success/failure response shapes.
* Updated controller imports to include `Post`, `Body`, and `ApiBody` decorators to support the new endpoint and its documentation. [[1]](diffhunk://#diff-4967457aa8181014bcd6aa0abfe5efef3ce16db9a5cca44bafb35b97d81b99a1L1-R1) [[2]](diffhunk://#diff-4967457aa8181014bcd6aa0abfe5efef3ce16db9a5cca44bafb35b97d81b99a1R10)

### Response Structure Updates

* Added a new `product_sk` field to the `ProductResponseDto` for mobile compatibility, mirroring the `id` field.
* Modified the `BarcodeService` to include the new `product_sk` field in the product response object.